### PR TITLE
added currency formatting for labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,8 @@
 					          .attr("cy", padding);
 
 					      // Add a label.
+
+					      var format = d3.format("$,.2f") // formats to a leading $ sign, with commas, and two places fixed precision after the decimal point
 					      marker.append("svg:text")
 					          .attr("x", padding)
 					          .attr("y", padding)
@@ -97,7 +99,9 @@
 					          .attr("x", padding)
 					          .attr("y", padding+12)
 					          .attr("dy", 20)
-					          .text(function(d) { return "$" + d.value.rev;});
+					          .text(function(d) { 
+					          	return format(d.value.rev);
+					          });
 
 					      function transform(d) {
 


### PR DESCRIPTION
This change formats the revenue amounts to a number with a leading $ sign, with commas, and two places fixed precision after the decimal point.

These examples helped me figure out the formatting:

http://bl.ocks.org/zanarmstrong/05c1e95bf7aa16c4768e

http://koaning.s3-website-us-west-2.amazonaws.com/html/d3format.html
